### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An easy lightweight tab bar controller that is scrollable and tab bar items are 
 <img src="https://github.com/raihan/ZRTabView/blob/master/Example/ZRTabView/ScreenShot.png" width="200" />
 
 ## Installation
-Available in [Cocoa Pods](http://cocoapods.org/?q=ZRTabView)
+Available in [CocoaPods](http://cocoapods.org/?q=ZRTabView)
 
 ```
 pod 'ZRTabView', '~> 0.1.0'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
